### PR TITLE
fix(injector): fixed rollup warning about source maps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1350,9 +1350,9 @@
       }
     },
     "@semantic-release/npm": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-7.0.9.tgz",
-      "integrity": "sha512-VsmmQF3/n7mDbm6AGL0yPD3QNTGsHdinBtkyyerN1eLgvhdGJ/vEeAvmDMARiuf5Ev9cFeCheF0wLyUZNlAkeA==",
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-7.0.10.tgz",
+      "integrity": "sha512-DXFEhgSt5u22imTWbw8wfcVGB90nFJNcjUBtJI3zswJojzZ7yXpY4i2Va5RBRQRTtj00BfG0stbilAtKrKp35g==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "^2.2.0",
@@ -1362,7 +1362,7 @@
         "lodash": "^4.17.15",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^5.0.0",
-        "npm": "^6.14.8",
+        "npm": "^6.14.9",
         "rc": "^1.2.8",
         "read-pkg": "^5.0.0",
         "registry-auth-token": "^4.0.0",
@@ -1399,15 +1399,15 @@
           }
         },
         "fs-extra": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
           "dev": true,
           "requires": {
             "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
+            "universalify": "^2.0.0"
           }
         },
         "get-stream": {
@@ -1436,14 +1436,6 @@
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
-          },
-          "dependencies": {
-            "universalify": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-              "dev": true
-            }
           }
         },
         "mimic-fn": {
@@ -1501,9 +1493,9 @@
           "dev": true
         },
         "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
           "dev": true
         },
         "which": {
@@ -4910,9 +4902,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "inquirer": {
@@ -6934,9 +6926,9 @@
       "dev": true
     },
     "npm": {
-      "version": "6.14.9",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.9.tgz",
-      "integrity": "sha512-yHi1+i9LyAZF1gAmgyYtVk+HdABlLy94PMIDoK1TRKWvmFQAt5z3bodqVwKvzY0s6dLqQPVsRLiwhJfNtiHeCg==",
+      "version": "6.14.11",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.11.tgz",
+      "integrity": "sha512-1Zh7LjuIoEhIyjkBflSSGzfjuPQwDlghNloppjruOH5bmj9midT9qcNT0tRUZRR04shU9ekrxNy9+UTBrqeBpQ==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.3.5",
@@ -6976,7 +6968,7 @@
         "infer-owner": "^1.0.4",
         "inflight": "~1.0.6",
         "inherits": "^2.0.4",
-        "ini": "^1.3.5",
+        "ini": "^1.3.8",
         "init-package-json": "^1.10.3",
         "is-cidr": "^3.0.0",
         "json-parse-better-errors": "^1.0.2",
@@ -7022,7 +7014,7 @@
         "npm-user-validate": "^1.0.1",
         "npmlog": "~4.1.2",
         "once": "~1.4.0",
-        "opener": "^1.5.1",
+        "opener": "^1.5.2",
         "osenv": "^0.1.5",
         "pacote": "^9.5.12",
         "path-is-inside": "~1.0.2",
@@ -8343,7 +8335,7 @@
           "dev": true
         },
         "ini": {
-          "version": "1.3.5",
+          "version": "1.3.8",
           "bundled": true,
           "dev": true
         },
@@ -9202,7 +9194,7 @@
           }
         },
         "opener": {
-          "version": "1.5.1",
+          "version": "1.5.2",
           "bundled": true,
           "dev": true
         },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,7 @@ export default {
   ],
   external,
   output: [
-    { file: pkg.main, format: 'cjs' },
+    { file: pkg.main, format: 'cjs', exports: 'auto' },
     { file: pkg.module, format: 'es' }
   ]
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ export default function versionInjector (userConfig?: Partial<VersionInjectorCon
       injector.injectIntoComments(config.injectInComments, fileName, version);
       if (injector.isCodeChanged()) {
         logger.log(`${pluginName} finished`);
-        return { code: injector.getCode() };
+        return { code: injector.getCode(), map: null };
       } else {
         logger.log(`file was not changed. did not write to file "${fileName}"`);
       }

--- a/src/utils/injector.ts
+++ b/src/utils/injector.ts
@@ -12,20 +12,20 @@ export class VIInjector {
   private codeChanged: boolean;
   private code: string;
 
-	/**
-	 * Construct utilities and pass in the desired logger
-	 * @param logger desired logger
-	 */
+  /**
+   * Construct utilities and pass in the desired logger
+   * @param logger desired logger
+   */
   constructor (logger: ILogger) {
     this.logger = logger;
     this.codeChanged = false;
     this.code = '';
   }
 
-	/**
-	 * Return the version number from `package.json`
-	 * @param packagePath path to `package.json`
-	 */
+  /**
+   * Return the version number from `package.json`
+   * @param packagePath path to `package.json`
+   */
   public getVersion (packagePath: string): string {
     const packageFile = JSON.parse(
       fs.readFileSync(path.resolve(packagePath), 'utf8')
@@ -54,10 +54,10 @@ export class VIInjector {
     return this.code;
   }
 
-	/**
-	 * Determine if the file extension is in the {@link SupportedFileExtensions}
-	 * @param fileName file name
-	 */
+  /**
+   * Determine if the file extension is in the {@link SupportedFileExtensions}
+   * @param fileName file name
+   */
   public getFileExtension (fileName: string): SupportedFileExtensions | null {
     let len: number = fileName.length;
     let ext: SupportedFileExtensions | null = null;
@@ -143,14 +143,14 @@ export class VIInjector {
     }
   }
 
-	/**
-	 * Inject the version number and/or date into the passed in code. Version
-	 * 	and/or date must be within the opening (`[${tagId}]`) and closing (`[/${tagId}]`) tags.
-	 * @param tagId tag id to look for
-	 * @param dateFormat date format of today's date to be injected
-	 * @param version verions to be injecte3d
-	 * @param code code to inject into
-	 */
+  /**
+   * Inject the version number and/or date into the passed in code. Version
+   * 	and/or date must be within the opening (`[${tagId}]`) and closing (`[/${tagId}]`) tags.
+   * @param tagId tag id to look for
+   * @param dateFormat date format of today's date to be injected
+   * @param version verions to be injecte3d
+   * @param code code to inject into
+   */
   private replaceVersionInTags (tagId: string, dateFormat: string, version: string, code: string): { code: string, replaceCount: number } {
     this.logger.debug(`starting injectIntoTags() with args: { tagId: "${tagId}", dateFormat: ${dateFormat}, version: ${version}, code: "${code ? code.substring(0, 12) + '...' : code}" }`);
     let replaceCount: number = 0;
@@ -178,16 +178,16 @@ export class VIInjector {
     return { code, replaceCount };
   }
 
-	/**
-	 * Inject the version number and/or date into the passed in tag.
-	 *  File extension must be in the {@link SupportedFileExtensions} type.
-	 * 	Extension is used to determin type of comment.
-	 * @param tag to look in
-	 * @param dateFormat date format of today's date to be injected
-	 * @param version verions to be injecte3d
-	 * @param fileType file type
-	 * @param code code to inject into
-	 */
+  /**
+   * Inject the version number and/or date into the passed in tag.
+   *  File extension must be in the {@link SupportedFileExtensions} type.
+   * 	Extension is used to determin type of comment.
+   * @param tag to look in
+   * @param dateFormat date format of today's date to be injected
+   * @param version verions to be injecte3d
+   * @param fileType file type
+   * @param code code to inject into
+   */
   private replaceVersionInComments (tag: string, dateFormat: string, version: string, fileExtension: SupportedFileExtensions, code: string): string {
     this.logger.debug(`starting injectIntoComments() with args: { tag: "${tag}", dateFormat: "${dateFormat}", version: "${version}", fileExtension: "${fileExtension}", code: "${code ? code.substring(0, 12) + '...' : code}" }`);
     let injectValue = this.replaceVersion(tag, version);
@@ -216,12 +216,12 @@ export class VIInjector {
     return code;
   }
 
-	/**
-	 * Remove the tagId from the passed in tag. Tags are wrapped in brackets `[]`
-	 * 	It will remove `[${tagId}]` and `[/${tagId}]`
-	 * @param tag tag string
-	 * @param tagId tag id that should be stripped
-	 */
+  /**
+   * Remove the tagId from the passed in tag. Tags are wrapped in brackets `[]`
+   * 	It will remove `[${tagId}]` and `[/${tagId}]`
+   * @param tag tag string
+   * @param tagId tag id that should be stripped
+   */
   private stripTags (tag: string, tagId: string): string {
     const regexp = new RegExp(`(\\[${tagId}]|\\[\\/${tagId}])`, 'g');
     this.logger.debug(`tag before stripping tagId`, tag);
@@ -242,11 +242,11 @@ export class VIInjector {
     // return new RegExp(`(\\[${tagId}])(([a-zA-Z{} ,:;!()_@\\-"'\\\\\\/\\d])+)(\\[\\/${tagId}])`, 'g');
   }
 
-	/**
-	 * Replace `{version}` with the version passed in
-	 * @param tag tag string
-	 * @param version version number passed in
-	 */
+  /**
+   * Replace `{version}` with the version passed in
+   * @param tag tag string
+   * @param version version number passed in
+   */
   private replaceVersion (tag: string, version: string): string {
     this.logger.debug(`tag before replacing version: "${tag}"`);
     let newTag = tag.replace('{version}', version);
@@ -257,12 +257,12 @@ export class VIInjector {
     return newTag;
   }
 
-	/**
-	 * Replace `{date}` with the current date in the passed in format.
-	 * 	See [dateformat](https://www.npmjs.com/package/dateformat) for supported formats
-	 * @param tag tag string
-	 * @param version version number passed in
-	 */
+  /**
+   * Replace `{date}` with the current date in the passed in format.
+   * 	See [dateformat](https://www.npmjs.com/package/dateformat) for supported formats
+   * @param tag tag string
+   * @param version version number passed in
+   */
   private replaceDate (tag: string, dateFormat: string): string {
     this.logger.debug(`tag before replacing date: "${tag}"`);
     let newTag = tag.replace('{date}', dateformat(dateFormat));

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -101,7 +101,7 @@ describe('injectVersion()', () => {
     //const writeToFileSpy = jest.spyOn(VIInjector.prototype, 'writeToFile').mockImplementation(() => null);
     jest.spyOn(VIInjector.prototype, 'isCodeChanged').mockImplementation(() => true);
 
-    expect(result.renderChunk(code, chunk)).toStrictEqual({code:''});
+    expect(result.renderChunk(code, chunk)).toStrictEqual({ code: '', map: null });
     expect(setCodeSpy).toHaveBeenCalledWith(code);
     expect(injectIntoTagsSpy).toHaveBeenCalledWith(basicConfig.injectInTags, 'file.js', '1.1.1');
     expect(injectIntoCommentsSpy).toHaveBeenCalledWith(basicConfig.injectInComments, 'file.js', '1.1.1');


### PR DESCRIPTION
added config to tell rollup that sourcemaps are not needed with VI since VI only replaces string(s)
in code. Existing sourcemaps are still valid.

#17