### PR TITLE
Respect `SOURCE_DATE_EPOCH`

### DIFF
--- a/src/utils/injector.ts
+++ b/src/utils/injector.ts
@@ -264,7 +264,10 @@ export class VIInjector {
    */
   private replaceDate (tag: string, dateFormat: string): string {
     this.logger.debug(`tag before replacing date: "${tag}"`);
-    let newTag = tag.replace('{date}', dateformat(dateFormat));
+    const date = "SOURCE_DATE_EPOCH" in process.env
+      ? new Date(+(process.env.SOURCE_DATE_EPOCH as string)) //TODO memoise?
+      : new Date();
+    let newTag = tag.replace('{date}', dateformat(date, dateFormat));
     if (newTag === tag) {
       this.logger.debug(`could not find "{date}" placeholder in tag: "${tag}"`);
     }


### PR DESCRIPTION
[`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/docs/source-date-epoch/) is a mechanism for allowing timestamped build artifacts while still being byte-for-byte reproducible. The `dateformat` overload you're currently using will get the current system time each time it's called, but with this change, it will instead create a `Date` object from `SOURCE_DATE_EPOCH` each time it's called, falling back to the old behaviour if it's not set.